### PR TITLE
Upgrade to debian stretch and PG 9.6

### DIFF
--- a/postgres/Vagrantfile
+++ b/postgres/Vagrantfile
@@ -7,11 +7,11 @@ Vagrant.configure("2") do |config|
     apt-get dist-upgrade -y
 
     echo "Installing postgres"
-    apt-get install -y postgresql-client-9.4 postgresql-9.4
+    apt-get install -y postgresql-client-9.5 postgresql-9.5
 
     echo "Configuring and restarting PostgreSQL"
-    echo 'listen_addresses = '"'"'*'"'" >> /etc/postgresql/9.4/main/postgresql.conf
-    echo 'host    all             all             10.0.2.0/24            md5' >> /etc/postgresql/9.4/main/pg_hba.conf
+    echo 'listen_addresses = '"'"'*'"'" >> /etc/postgresql/9.5/main/postgresql.conf
+    echo 'host    all             all             10.0.2.0/24            md5' >> /etc/postgresql/9.5/main/pg_hba.conf
     systemctl restart postgresql
 
     echo "Creating vagrant user and database"

--- a/postgres/Vagrantfile
+++ b/postgres/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure("2") do |config|
     systemctl restart postgresql
 
     echo "Creating vagrant user and database"
-    echo "CREATE ROLE vagrant CREATEDB CREATEROLE CREATEUSER LOGIN UNENCRYPTED PASSWORD 'vagrant'" | sudo -u postgres psql -a -f -
+    echo "CREATE ROLE vagrant CREATEDB CREATEROLE LOGIN UNENCRYPTED PASSWORD 'vagrant'" | sudo -u postgres psql -a -f -
     echo "CREATE DATABASE vagrant OWNER vagrant" | sudo -u postgres psql -a -f -
 
     echo "Preparing for packaging"

--- a/postgres/Vagrantfile
+++ b/postgres/Vagrantfile
@@ -7,7 +7,7 @@ Vagrant.configure("2") do |config|
     apt-get dist-upgrade -y
 
     echo "Installing postgres"
-    apt-get install -y postgresql-client-9.5 postgresql-9.5
+    apt-get install -y psmisc postgresql-client-9.5 postgresql-9.5
 
     echo "Configuring and restarting PostgreSQL"
     echo 'listen_addresses = '"'"'*'"'" >> /etc/postgresql/9.5/main/postgresql.conf


### PR DESCRIPTION
The CREATEUSER option is gone in 9.6.

Also in order to have the command `killall` you need to install the `psmisc`.